### PR TITLE
feat: deployments list pagination [27]

### DIFF
--- a/src/components/DeploymentsList.tsx
+++ b/src/components/DeploymentsList.tsx
@@ -11,6 +11,7 @@ import {
   useMediaQuery,
 } from '@chakra-ui/react'
 import { DeleteIcon, EditIcon } from '@liftedinit/ui'
+import Pagination from './Pagination'
 
 const formatUrlDisplay = (url: string) => {
   if (url.length <= 34) {
@@ -86,86 +87,103 @@ const Td = (props: any) => {
 }
 
 export default function DeploymentsList(props: any) {
-  const { deployments, onDelete, onEdit } = props
+  const {
+    currentPage,
+    deployments,
+    onDelete,
+    onEdit,
+    nextBtnProps,
+    prevBtnProps,
+    numPages,
+  } = props
   const theme = useTheme()
   const [isMobile] = useMediaQuery('(max-width: 640px)')
 
   return (
-    <Grid
-      templateColumns={isMobile ? '1fr' : '1fr 1fr 2fr 1fr'}
-      gap={0}
-      mt={4}
-      mb={40}
-    >
-      <GridItem
-        colSpan={1}
-        borderBottom={`1px solid ${theme.colors.gray[200]}`}
-        py={2}
-        display={isMobile ? 'none' : 'flex'}
-        alignItems="center"
+    <>
+      <Grid
+        templateColumns={isMobile ? '1fr' : '1fr 1fr 2fr 1fr'}
+        gap={0}
+        mt={4}
+        mb={10}
       >
-        <Text fontWeight="bold">Name</Text>
-      </GridItem>
-      <GridItem
-        colSpan={1}
-        borderBottom={`1px solid ${theme.colors.gray[200]}`}
-        py={2}
-        display={isMobile ? 'none' : 'flex'}
-        alignItems="center"
-      >
-        <Text fontWeight="bold">Description</Text>
-      </GridItem>
-      <GridItem
-        colSpan={1}
-        borderBottom={`1px solid ${theme.colors.gray[200]}`}
-        py={2}
-        display={isMobile ? 'none' : 'flex'}
-        alignItems="center"
-      >
-        <Text fontWeight="bold">URL</Text>
-      </GridItem>
-      <GridItem
-        colSpan={1}
-        borderBottom={`1px solid ${theme.colors.gray[200]}`}
-        display={isMobile ? 'none' : 'flex'}
-      ></GridItem>
-      {deployments.map((deployment: any) => {
-        const { uuid, siteName, siteDescription, deploymentUrl } = deployment
-        return (
-          <Fragment key={uuid}>
-            <Td label="Name" value={siteName} />
-            <Td label="Description" value={siteDescription} />
-            <Td label="URL" value={deploymentUrl} />
+        <GridItem
+          colSpan={1}
+          borderBottom={`1px solid ${theme.colors.gray[200]}`}
+          py={2}
+          display={isMobile ? 'none' : 'flex'}
+          alignItems="center"
+        >
+          <Text fontWeight="bold">Name</Text>
+        </GridItem>
+        <GridItem
+          colSpan={1}
+          borderBottom={`1px solid ${theme.colors.gray[200]}`}
+          py={2}
+          display={isMobile ? 'none' : 'flex'}
+          alignItems="center"
+        >
+          <Text fontWeight="bold">Description</Text>
+        </GridItem>
+        <GridItem
+          colSpan={1}
+          borderBottom={`1px solid ${theme.colors.gray[200]}`}
+          py={2}
+          display={isMobile ? 'none' : 'flex'}
+          alignItems="center"
+        >
+          <Text fontWeight="bold">URL</Text>
+        </GridItem>
+        <GridItem
+          colSpan={1}
+          borderBottom={`1px solid ${theme.colors.gray[200]}`}
+          display={isMobile ? 'none' : 'flex'}
+        ></GridItem>
+        {deployments.map((deployment: any) => {
+          const { uuid, siteName, siteDescription, deploymentUrl } = deployment
+          return (
+            <Fragment key={uuid}>
+              <Td label="Name" value={siteName} />
+              <Td label="Description" value={siteDescription} />
+              <Td label="URL" value={deploymentUrl} />
 
-            <GridItem
-              colSpan={1}
-              borderBottom={`1px solid ${theme.colors.gray[200]}`}
-              py={2}
-              display="flex"
-              alignItems="center"
-              justifyContent={isMobile ? 'flex-start' : 'flex-end'}
-            >
-              <IconButton
-                onClick={() => onEdit(uuid)}
-                aria-label="Redeploy"
-                icon={<EditIcon />}
-                size="sm"
-                fontWeight="normal"
-                mr={3}
-              />
-              <IconButton
-                onClick={() => onDelete(uuid)}
-                aria-label="Delete"
-                icon={<DeleteIcon />}
-                size="sm"
-                fontWeight="normal"
+              <GridItem
+                colSpan={1}
+                borderBottom={`1px solid ${theme.colors.gray[200]}`}
+                py={2}
+                display="flex"
+                alignItems="center"
+                justifyContent={isMobile ? 'flex-start' : 'flex-end'}
               >
-                Delete
-              </IconButton>
-            </GridItem>
-          </Fragment>
-        )
-      })}
-    </Grid>
+                <IconButton
+                  onClick={() => onEdit(uuid)}
+                  aria-label="Redeploy"
+                  icon={<EditIcon />}
+                  size="sm"
+                  fontWeight="normal"
+                  mr={3}
+                />
+                <IconButton
+                  onClick={() => onDelete(uuid)}
+                  aria-label="Delete"
+                  icon={<DeleteIcon />}
+                  size="sm"
+                  fontWeight="normal"
+                >
+                  Delete
+                </IconButton>
+              </GridItem>
+            </Fragment>
+          )
+        })}
+      </Grid>
+
+      <Pagination
+        currentPage={currentPage}
+        nextBtnProps={nextBtnProps}
+        prevBtnProps={prevBtnProps}
+        numPages={numPages}
+      />
+    </>
   )
 }

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react'
+import { Button, Flex, Icon, Text, useTheme } from '@chakra-ui/react'
+import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io'
+
+const PagButton = (props: any) => {
+  const theme = useTheme()
+
+  return (
+    <Button
+      variant="outline"
+      mx={1}
+      px={4}
+      py={2}
+      rounded="md"
+      fontWeight="normal"
+      sx={{
+        '&[disabled]': {
+          bg: theme.colors.white,
+        },
+        '&:hover[disabled]': {
+          bg: theme.colors.white,
+        },
+      }}
+      disabled={props.disabled}
+      onClick={props.onClick}
+      data-testid={props.id}
+    >
+      {props.children}
+    </Button>
+  )
+}
+
+export default function Pagination(props: any) {
+  const { currentPage, nextBtnProps, prevBtnProps, numPages } = props
+  const [pages, setPages] = useState<any>([])
+
+  useEffect(() => {
+    if (numPages === 1) return
+    let arr = []
+    for (let i = 1; i <= numPages; i += 1) {
+      arr.push(i)
+    }
+    setPages(arr)
+  }, [numPages]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!pages.length) return null
+
+  return (
+    <Flex
+      wrap={'wrap'}
+      justifyContent="center"
+      mb={10}
+      data-testid="pagination"
+    >
+      <PagButton {...prevBtnProps} id="prev-btn">
+        <Icon as={IoIosArrowBack} boxSize={4} />
+      </PagButton>
+      <Flex
+        justifyContent="center"
+        alignItems="center"
+        display={{
+          base: 'flex',
+          md: 'none',
+        }}
+        px={4}
+      >
+        <Text>
+          {currentPage}/{numPages}
+        </Text>
+      </Flex>
+      {pages.map((page: number, index: number) => (
+        <Flex
+          key={`page-${index}`}
+          py={2}
+          px={3}
+          fontWeight={page === currentPage ? 'bold' : 'normal'}
+          display={{
+            base: 'none',
+            md: 'block',
+          }}
+          className={page === currentPage ? 'active' : ''}
+          data-testid={`page-${index + 1}`}
+        >
+          {page}
+        </Flex>
+      ))}
+      <PagButton {...nextBtnProps} id="next-btn">
+        <Icon as={IoIosArrowForward} boxSize={4} />
+      </PagButton>
+    </Flex>
+  )
+}

--- a/src/components/__tests__/Pagination.test.tsx
+++ b/src/components/__tests__/Pagination.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import Pagination from '../Pagination'
+import { QueryClient, QueryClientProvider } from 'react-query'
+
+jest.mock('@chakra-ui/react', () => ({
+  ...jest.requireActual('@chakra-ui/react'),
+  useTheme: () => ({
+    colors: {
+      white: '#FFFFFF',
+    },
+  }),
+}))
+
+const mockProps = {
+  onDelete: jest.fn(),
+  onEdit: jest.fn(),
+  currentPage: 1,
+  nextBtnProps: {
+    onClick: jest.fn(),
+  },
+  prevBtnProps: {
+    onClick: jest.fn(),
+  },
+  numPages: 1,
+}
+
+const queryClient = new QueryClient()
+
+describe('Pagination', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('does not render if one page', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Pagination {...mockProps} />
+      </QueryClientProvider>,
+    )
+    expect(screen.queryByTestId('pagination')).not.toBeInTheDocument()
+  })
+
+  it('renders if more than one page', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Pagination {...{ ...mockProps, numPages: 2 }} />
+      </QueryClientProvider>,
+    )
+    expect(screen.getByTestId('pagination')).toBeInTheDocument()
+    expect(screen.getByTestId('prev-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('page-1')).toBeInTheDocument()
+    expect(screen.getByTestId('page-1')).toHaveClass('active')
+    expect(screen.getByTestId('page-2')).toBeInTheDocument()
+    expect(screen.getByTestId('next-btn')).toBeInTheDocument()
+  })
+
+  it('renders second page as active', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Pagination {...{ ...mockProps, numPages: 2, currentPage: 2 }} />
+      </QueryClientProvider>,
+    )
+    expect(screen.getByTestId('page-2')).toHaveClass('active')
+  })
+
+  it('renders prev btn as disabled', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Pagination
+          {...{ ...mockProps, numPages: 2, prevBtnProps: { disabled: true } }}
+        />
+      </QueryClientProvider>,
+    )
+    expect(screen.getByTestId('prev-btn')).toBeDisabled()
+  })
+
+  it('renders next btn as disabled', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Pagination
+          {...{ ...mockProps, numPages: 2, nextBtnProps: { disabled: true } }}
+        />
+      </QueryClientProvider>,
+    )
+    expect(screen.getByTestId('next-btn')).toBeDisabled()
+  })
+})

--- a/src/features/deployments/queries.ts
+++ b/src/features/deployments/queries.ts
@@ -135,6 +135,8 @@ export function useDeploymentList({ address }: DeploymentsListArgs) {
             payload,
           })
         }
+
+        // TODO: revisit this approach, web.list returns a maximum of 100 websites
         const response: WebDeployInfo[] = await activeNetwork?.web?.list({
           order: ListOrderType.descending,
           filters,

--- a/src/features/deployments/queries.ts
+++ b/src/features/deployments/queries.ts
@@ -13,8 +13,7 @@ import { useMutation, useQueryClient } from 'react-query'
 import { v5 as uuidv5 } from 'uuid'
 import { WebDeployInfoWithUuid } from './types'
 
-// TODO: Pagination
-// const PAGE_SIZE = 11
+const PAGE_SIZE = 11
 
 export function useCreateDeployment() {
   const [, network] = useNetworkContext()
@@ -114,9 +113,14 @@ export function useDeploymentList({ address }: DeploymentsListArgs) {
   const [data, setData] = React.useState<WebDeployInfoWithUuid[]>([])
   const [activeNetwork, ,] = useNetworkContext()
   const [loading, setLoading] = React.useState(true)
-  // TODO: Pagination
-  // const [deployments, setDeployments] = React.useState<ArrayBuffer[]>([])
+  const [visibleDeployments, setVisibleDeployments] = React.useState<
+    WebDeployInfoWithUuid[]
+  >([])
+  const [deployments, setDeployments] = React.useState<WebDeployInfoWithUuid[]>(
+    [],
+  )
   const [error, setError] = React.useState(Error)
+  const [currentPage, setCurrentPage] = React.useState<any>(1)
 
   useEffect(() => {
     const fetchQuery = async () => {
@@ -132,8 +136,6 @@ export function useDeploymentList({ address }: DeploymentsListArgs) {
           })
         }
         const response: WebDeployInfo[] = await activeNetwork?.web?.list({
-          // TODO: Pagination
-          // count: PAGE_SIZE,
           order: ListOrderType.descending,
           filters,
         })
@@ -146,6 +148,8 @@ export function useDeploymentList({ address }: DeploymentsListArgs) {
         )
 
         setData(data)
+        setVisibleDeployments(data.slice(0, PAGE_SIZE))
+        setCurrentPage(1)
         setLoading(false)
       } catch (err) {
         setError(err as Error)
@@ -153,36 +157,37 @@ export function useDeploymentList({ address }: DeploymentsListArgs) {
       }
     }
     fetchQuery()
-  }, [activeNetwork, address])
+  }, [activeNetwork, address, deployments])
 
-  // TODO: Pagination
-  // const hasNextPage = data.length === PAGE_SIZE
-  // const visibleDeployments = hasNextPage ? data.slice(0, PAGE_SIZE - 1) : data
+  const total = data.length
+  const numPages = Math.ceil(total / PAGE_SIZE)
+  const hasNextPage = currentPage < numPages
 
   return {
     error: error?.message,
     isError: error,
     isLoading: loading,
-    data,
-    // TODO: Pagination
-    // hasNextPage,
-    // currPageCount: deployments.length,
-    //   prevBtnProps: {
-    //     disabled: deployments.length === 0,
-    //     onClick: () => {
-    //       setDeployments(s => s.slice(1))
-    //     },
-    //   },
-    //   nextBtnProps: {
-    //     disabled: !hasNextPage,
-    //     onClick: () => {
-    //       const lastDeployment = data[PAGE_SIZE - 1]
-    //       setDeployments(s => [lastDeployment, ...s])
-    //     },
-    //   },
-    //   data: {
-    //     count: data.length,
-    //     transactions: visibleDeployments ?? [],
-    //   },
+    deployments: data,
+    setDeployments,
+    visibleDeployments,
+    total,
+    numPages,
+    currentPage,
+    prevBtnProps: {
+      disabled: currentPage === 1,
+      onClick: () => {
+        const prevIndex = PAGE_SIZE * (currentPage - 2)
+        setVisibleDeployments(data.slice(prevIndex, prevIndex + PAGE_SIZE))
+        setCurrentPage(currentPage - 1)
+      },
+    },
+    nextBtnProps: {
+      disabled: !hasNextPage,
+      onClick: () => {
+        const nextIndex = PAGE_SIZE * currentPage
+        setVisibleDeployments(data.slice(nextIndex, nextIndex + PAGE_SIZE))
+        setCurrentPage(currentPage + 1)
+      },
+    },
   }
 }

--- a/src/views/dashboard/dashboard.tsx
+++ b/src/views/dashboard/dashboard.tsx
@@ -16,10 +16,7 @@ import { AnonymousIdentity } from '@liftedinit/many-js'
 import CreateDeployment from '../../components/CreateDeployment'
 import ConfirmDelete from '../../components/ConfirmDelete'
 import DeploymentsList from '../../components/DeploymentsList'
-import {
-  useDeploymentList,
-  WebDeployInfoWithUuid,
-} from '../../features/deployments'
+import { useDeploymentList } from '../../features/deployments'
 
 export function Dashboard() {
   const account = useAccountsStore(s => s.byId.get(s.activeId))
@@ -36,20 +33,22 @@ export function Dashboard() {
   } = useDisclosure()
 
   const [isMobile] = useMediaQuery('(max-width: 640px)')
-  const [deployments, setDeployments] = useState<WebDeployInfoWithUuid[]>([])
   const [activeDeploymentUuid, setActiveDeploymentUuid] = useState('')
   const [isRedeploying, setIsRedeploying] = useState(false)
 
   // TODO: Handle error
-  const { data: allDeployments } = useDeploymentList({
+  const {
+    deployments,
+    setDeployments,
+    visibleDeployments,
+    nextBtnProps,
+    prevBtnProps,
+    numPages,
+    total,
+    currentPage,
+  } = useDeploymentList({
     address: account?.address,
   })
-
-  useEffect(() => {
-    if (allDeployments) {
-      setDeployments(allDeployments)
-    }
-  }, [allDeployments])
 
   const handleDeleteDeployment = (uuid: string) => {
     setActiveDeploymentUuid(uuid)
@@ -103,9 +102,14 @@ export function Dashboard() {
         </Grid>
 
         <DeploymentsList
-          deployments={deployments}
+          deployments={visibleDeployments}
           onDelete={handleDeleteDeployment}
           onEdit={handleEditDeployment}
+          nextBtnProps={nextBtnProps}
+          prevBtnProps={prevBtnProps}
+          numPages={numPages}
+          total={total}
+          currentPage={currentPage}
         />
       </Box>
 
@@ -115,8 +119,8 @@ export function Dashboard() {
         deployments={deployments}
         activeDeploymentUuid={activeDeploymentUuid}
         setDeployments={setDeployments}
-	isRedeploying={isRedeploying}
-	setIsRedeploying={setIsRedeploying}
+        isRedeploying={isRedeploying}
+        setIsRedeploying={setIsRedeploying}
       />
       <ConfirmDelete
         isOpen={confirmDeleteIsOpen}


### PR DESCRIPTION
deployments list pagination

## Description

- create pagination component/tests
- refactor `useDeploymentList` hook to support deployment state

Fixes # (issue)

## Testing

Create more than 11 deployments, see pagination

## Screenshots (if applicable)

<img width="810" alt="Screen Shot 2023-09-25 at 7 01 48 PM" src="https://github.com/liftedinit/ghostcloud/assets/649166/6b810244-e196-47ee-8f07-0b2a7e42e692">

## Checklist:

- [x] I have read and followed the CONTRIBUTING guidelines for this project.
- [x] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.
