### PR TITLE
fix: deployment modal/account menu focus behavior [33]

### DIFF
--- a/src/components/CreateDeployment.tsx
+++ b/src/components/CreateDeployment.tsx
@@ -357,11 +357,10 @@ export default function CreateDeployment({
                     height: '100px',
                     padding: 4,
                     borderWidth: 1,
-                    borderRadius: 2,
-                    borderColor: theme.colors.gray[100],
+                    borderRadius: 6,
+                    borderColor: theme.colors.gray[400],
                     backgroundColor: theme.colors.gray[50],
                     color: theme.colors.gray[500],
-                    outline: 'none',
                     cursor: 'pointer',
                   }}
                 >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -212,38 +212,33 @@ export default function Header({ onAddModalOpen }: any) {
                     p={4}
                   >
                     <Stack as="nav" spacing={4}>
-                      {!isAnonymous && (
-                        <>
-                          <Text fontWeight={'bold'}>{account?.name}</Text>
-                          <Button
-                            variant="outline"
+                      <>
+                        <Text fontWeight={'bold'}>{account?.name}</Text>
+                        <Button
+                          variant="outline"
+                          sx={{
+                            background: copied
+                              ? theme.colors.gray[100]
+                              : 'none',
+                          }}
+                          onClick={() => {
+                            setCopied(true)
+                            setTimeout(() => setCopied(false), 1000)
+                            navigator.clipboard.writeText(
+                              account?.address.toString() || '',
+                            )
+                          }}
+                        >
+                          <Box
                             sx={{
-                              transition: 'background 1s',
-                              background: copied
-                                ? theme.colors.gray[300]
-                                : 'none',
-                            }}
-                            onClick={() => {
-                              setCopied(true)
-                              setTimeout(() => setCopied(false), 1000)
-                              navigator.clipboard.writeText(
-                                account?.address.toString() || '',
-                              )
+                              pr: 22,
                             }}
                           >
-                            <Box
-                              sx={{
-                                pr: 22,
-                              }}
-                            >
-                              {account?.address.toString().slice(0, 4)}...
-                              {account?.address.toString().slice(-4)}
-                            </Box>
-                            <Icon as={copied ? BiCheck : BiCopy} w={5} h={5} />
-                          </Button>
-                        </>
-                      )}
-                      {!isAnonymous ? (
+                            {account?.address.toString().slice(0, 4)}...
+                            {account?.address.toString().slice(-4)}
+                          </Box>
+                          <Icon as={copied ? BiCheck : BiCopy} w={5} h={5} />
+                        </Button>
                         <Button
                           variant="outline"
                           onClick={() => {
@@ -253,7 +248,7 @@ export default function Header({ onAddModalOpen }: any) {
                         >
                           Log Out
                         </Button>
-                      ) : null}
+                      </>
                     </Stack>
                   </PopoverBody>
                 </PopoverContent>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {
   Box,
+  Button,
   Container,
   Grid,
   GridItem,
@@ -190,7 +191,17 @@ export default function Header({ onAddModalOpen }: any) {
                     size="lg"
                     icon={<BiSolidUser />}
                     aria-label="Account"
-                    onClick={accountOpen ? onAccountClose : onAccountOpen}
+                    onClick={() => {
+                      if (isAnonymous) {
+                        handleLogin()
+                        return
+                      }
+                      if (accountOpen) {
+                        onAccountClose()
+                      } else {
+                        onAccountOpen()
+                      }
+                    }}
                     bg={theme.colors.white}
                     mr={-4}
                   />
@@ -204,20 +215,13 @@ export default function Header({ onAddModalOpen }: any) {
                       {!isAnonymous && (
                         <>
                           <Text fontWeight={'bold'}>{account?.name}</Text>
-                          <Box
+                          <Button
+                            variant="outline"
                             sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              border: `1px solid ${theme.colors.gray[300]}`,
-                              py: 2,
-                              px: 4,
-                              borderRadius: '4px',
-                              cursor: 'pointer',
                               transition: 'background 1s',
                               background: copied
                                 ? theme.colors.gray[300]
                                 : 'none',
-                              width: 'fit-content',
                             }}
                             onClick={() => {
                               setCopied(true)
@@ -236,28 +240,20 @@ export default function Header({ onAddModalOpen }: any) {
                               {account?.address.toString().slice(-4)}
                             </Box>
                             <Icon as={copied ? BiCheck : BiCopy} w={5} h={5} />
-                          </Box>
+                          </Button>
                         </>
                       )}
-
-                      {isAnonymous ? (
-                        <NavLink
-                          onClick={() => {
-                            handleLogin()
-                          }}
-                        >
-                          Log In
-                        </NavLink>
-                      ) : (
-                        <NavLink
+                      {!isAnonymous ? (
+                        <Button
+                          variant="outline"
                           onClick={() => {
                             handleLogout()
                             onAccountClose()
                           }}
                         >
                           Log Out
-                        </NavLink>
-                      )}
+                        </Button>
+                      ) : null}
                     </Stack>
                   </PopoverBody>
                 </PopoverContent>


### PR DESCRIPTION
## Description

- Adjust styling of dropzone so it is outlined on focus and more closely aligns with other input presentation
- Make account icon open login modal if not logged in instead of popover

## Related Issue


Fixes # (issue)

- https://github.com/liftedinit/ghostcloud/issues/33


## Testing

1. Open "Create Deployment" modal
2. Tab through the form, see that dropzone now has focus outline

## Breaking Changes (if applicable)

<!-- Please describe any breaking changes and your plan to handle them. -->
<!-- A breaking change is a change to this module's API that might cause consumers to fail. -->
<!-- e.g. modifying required parameters, renaming a public method, changing a response type -->

## Screenshots (if applicable)

<img width="380" alt="Screen Shot 2023-09-28 at 5 48 13 PM" src="https://github.com/liftedinit/ghostcloud/assets/649166/57c12abc-4a3d-4542-b761-239bf10e3d80">
<img width="318" alt="Screen Shot 2023-09-29 at 3 57 04 PM" src="https://github.com/liftedinit/ghostcloud/assets/649166/77d0cb60-d782-4761-8dbb-6527da0e1574">


## Checklist:

- [ ] I have read and followed the CONTRIBUTING guidelines for this project.
- [ ] I have added or updated tests and they pass.
- [ ] I have added or updated documentation and it is accurate.
- [ ] I have noted any breaking changes in this module or downstream modules.
