### PR TITLE
feat: custom domain support and deployment list refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
         "@fontsource/roboto": "^4.5.8",
-        "@liftedinit/many-js": "^0.1.0-alpha.13",
+        "@liftedinit/many-js": "github:fmorency/many-js#custom-domain",
         "@liftedinit/ui": "github:liftedinit/lifted-ui",
         "@web3auth/openlogin-adapter": "^2.1.3",
         "@web3auth/web3auth": "^2.1.3",
@@ -3555,9 +3555,9 @@
       }
     },
     "node_modules/@jest/expect/node_modules/@types/yargs": {
-      "version": "17.0.24",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
-      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.26.tgz",
+      "integrity": "sha512-Y3vDy2X6zw/ZCumcwLpdhM5L7jmyGpmBCTYMHDLqT2IKVMYRRLdv6ZakA+wxhra6Z/3bwhNbNl9bDGXaFU+6rw==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -4052,9 +4052,8 @@
       }
     },
     "node_modules/@liftedinit/many-js": {
-      "version": "0.1.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/@liftedinit/many-js/-/many-js-0.1.0-alpha.13.tgz",
-      "integrity": "sha512-TenIfILSUWs/4FKZyfuxdTVLBQ8D57A3jQ0JHEujFv5sZ2M0NNsQlGzyXVYGpoM4qn4POobnfhWDPm492WnFZg==",
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/fmorency/many-js.git#7d9016b113123dde1bc4b3473079cfa7641f3284",
       "dependencies": {
         "@types/crc": "^3.4.0",
         "@types/jest": "^27.0.3",
@@ -4366,9 +4365,9 @@
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@liftedinit/many-js/node_modules/@types/yargs": {
-      "version": "17.0.24",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
-      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "version": "17.0.26",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.26.tgz",
+      "integrity": "sha512-Y3vDy2X6zw/ZCumcwLpdhM5L7jmyGpmBCTYMHDLqT2IKVMYRRLdv6ZakA+wxhra6Z/3bwhNbNl9bDGXaFU+6rw==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -5078,17 +5077,22 @@
       }
     },
     "node_modules/@liftedinit/many-js/node_modules/v8-to-istanbul": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
-      "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.2.tgz",
+      "integrity": "sha512-ZGBe7VAivuuoQXTeckpbYKTdtjXGcm3ZUHXC0PAk0CzFyuYvwi73a58iEKI3GkGD1c3EHc+EgfR1w5pgbfzJlQ==",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^1.6.0"
+        "convert-source-map": "^2.0.0"
       },
       "engines": {
         "node": ">=10.12.0"
       }
+    },
+    "node_modules/@liftedinit/many-js/node_modules/v8-to-istanbul/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/@liftedinit/many-js/node_modules/write-file-atomic": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4053,7 +4053,7 @@
     },
     "node_modules/@liftedinit/many-js": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/fmorency/many-js.git#7d9016b113123dde1bc4b3473079cfa7641f3284",
+      "resolved": "git+ssh://git@github.com/fmorency/many-js.git#91f4a6edfe9be3fa470012bf321ceeb40d81a709",
       "dependencies": {
         "@types/crc": "^3.4.0",
         "@types/jest": "^27.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
     "@fontsource/roboto": "^4.5.8",
-    "@liftedinit/many-js": "^0.1.0-alpha.13",
+    "@liftedinit/many-js": "github:fmorency/many-js#custom-domain",
     "@liftedinit/ui": "github:liftedinit/lifted-ui",
     "@web3auth/openlogin-adapter": "^2.1.3",
     "@web3auth/web3auth": "^2.1.3",

--- a/src/components/ConfirmDelete.tsx
+++ b/src/components/ConfirmDelete.tsx
@@ -44,7 +44,7 @@ export default function ConfirmDelete({
     onClose()
   }
 
-  const removeDeploymentMutation = useRemoveDeployment()
+  const removeDeploymentMutation = useRemoveDeployment(account?.address)
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>

--- a/src/components/CreateDeployment.tsx
+++ b/src/components/CreateDeployment.tsx
@@ -47,12 +47,14 @@ const MAX_FILE_SIZE_BYTES = 5242546 // This is the limit supported by the backen
 const SITE_NAME_MAX_LENGTH = 12
 const SITE_DESCRIPTION_MAX_LENGTH = 500
 const TRANSACTION_MEMO_MAX_LENGTH = 500
+const DOMAIN_MAX_LENGTH = 253
 
 interface FormState {
   siteName: string
   siteDescription?: string
   zipFile: File | undefined
   transactionMemo?: string
+  domain?: string
 }
 
 const initialFormState = {
@@ -60,6 +62,7 @@ const initialFormState = {
   siteDescription: '',
   zipFile: undefined,
   transactionMemo: '', // Must be a controlled element
+  domain: '', // Must be a controlled element
 }
 
 type CreateDeploymentProps = {
@@ -76,6 +79,7 @@ type Lengths = {
   siteName: number
   siteDescription: number
   transactionMemo: number
+  domain: number
 }
 
 export default function CreateDeployment({
@@ -113,10 +117,11 @@ export default function CreateDeployment({
     siteName: 0,
     siteDescription: 0,
     transactionMemo: 0,
+    domain: 0,
   })
   const account = useAccountsStore(s => s.byId.get(s.activeId))
-  const createDeploymentMutation = useCreateDeployment()
-  const updateDeploymentMutation = useUpdateDeployment()
+  const createDeploymentMutation = useCreateDeployment(account?.address)
+  const updateDeploymentMutation = useUpdateDeployment(account?.address)
 
   const remainingChars = (currentLength: number, maxLength: number) =>
     `${currentLength}/${maxLength}`
@@ -145,6 +150,7 @@ export default function CreateDeployment({
         siteDescription: foundDeployment.siteDescription,
         transactionMemo: foundDeployment.transactionMemo,
         zipFile: undefined,
+        domain: foundDeployment.domain,
       }))
     }
   }, [isOpen]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -215,6 +221,7 @@ export default function CreateDeployment({
           payload,
         } as DeploymentSource,
         memo: formState.transactionMemo ? [formState.transactionMemo] : [''],
+        domain: formState.domain,
       }
 
       await handleMutation(
@@ -336,7 +343,10 @@ export default function CreateDeployment({
                     maxLength={SITE_DESCRIPTION_MAX_LENGTH}
                   />
                   <Text fontSize="sm" color="gray.500">
-                    {remainingChars(lengths.siteDescription, 500)}
+                    {remainingChars(
+                      lengths.siteDescription,
+                      SITE_DESCRIPTION_MAX_LENGTH,
+                    )}
                   </Text>
                 </FormControl>
 
@@ -360,7 +370,32 @@ export default function CreateDeployment({
                     maxLength={TRANSACTION_MEMO_MAX_LENGTH}
                   />
                   <Text fontSize="sm" color="gray.500">
-                    {remainingChars(lengths.transactionMemo, 500)}
+                    {remainingChars(
+                      lengths.transactionMemo,
+                      TRANSACTION_MEMO_MAX_LENGTH,
+                    )}
+                  </Text>
+                </FormControl>
+
+                <FormControl>
+                  <Flex align="center">
+                    <FormLabel htmlFor="domain">Custom domain</FormLabel>
+                    <Box ml="auto">
+                      <Info id="domain" />
+                    </Box>
+                  </Flex>
+                  <Input
+                    id="domain"
+                    name="domain"
+                    placeholder=""
+                    size="lg"
+                    value={formState.domain}
+                    onChange={handleInputChange}
+                    borderColor={theme.colors.gray[400]}
+                    maxLength={DOMAIN_MAX_LENGTH}
+                  />
+                  <Text fontSize="sm" color="gray.500">
+                    {remainingChars(lengths.domain, DOMAIN_MAX_LENGTH)}
                   </Text>
                 </FormControl>
 

--- a/src/components/DeploymentsList.tsx
+++ b/src/components/DeploymentsList.tsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react'
 import { DeleteIcon, EditIcon } from '@liftedinit/ui'
 import Pagination from './Pagination'
+import { WebDeployInfoWithUuid } from '../features/deployments'
 
 const formatUrlDisplay = (url: string) => {
   if (url.length <= 34) {
@@ -102,7 +103,7 @@ export default function DeploymentsList(props: any) {
   return (
     <>
       <Grid
-        templateColumns={isMobile ? '1fr' : '1fr 1fr 2fr 1fr'}
+        templateColumns={isMobile ? '1fr' : '1fr 1fr 2fr 1fr 1fr'}
         gap={0}
         mt={4}
         mb={10}
@@ -137,15 +138,26 @@ export default function DeploymentsList(props: any) {
         <GridItem
           colSpan={1}
           borderBottom={`1px solid ${theme.colors.gray[200]}`}
+          py={2}
+          display={isMobile ? 'none' : 'flex'}
+          alignItems="center"
+        >
+          <Text fontWeight="bold">Domain</Text>
+        </GridItem>
+        <GridItem
+          colSpan={1}
+          borderBottom={`1px solid ${theme.colors.gray[200]}`}
           display={isMobile ? 'none' : 'flex'}
         ></GridItem>
-        {deployments.map((deployment: any) => {
-          const { uuid, siteName, siteDescription, deploymentUrl } = deployment
+        {deployments.map((deployment: WebDeployInfoWithUuid) => {
+          const { uuid, siteName, siteDescription, deploymentUrl, domain } =
+            deployment
           return (
             <Fragment key={uuid}>
               <Td label="Name" value={siteName} />
               <Td label="Description" value={siteDescription} />
               <Td label="URL" value={deploymentUrl} />
+              <Td label="Domain" value={domain} />
 
               <GridItem
                 colSpan={1}

--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -3,13 +3,15 @@ import { BiInfoCircle } from 'react-icons/bi'
 
 export const tips = {
   manyAddress:
-    'A unique address associated with your account that identfies you within the many network.',
+    'A unique address associated with your account that identifies you within the many network.',
   siteName: 'The randomly generated identifier for your deployment.',
   siteDescription:
     'A description for your deployment. This must be between 0-500 characters in length.',
   transactionMemo: 'A string associated with a transaction in Web3',
   deploymentFile:
     'Select a zip file less that 5MB in size which contains your site build. This archive must contain an index.html file in the root.',
+  domain:
+    'The custom domain name you would like to use for your deployment. This must be between 0-253 characters in length.',
 }
 
 type TipKeys = keyof typeof tips


### PR DESCRIPTION
- Support deployment/update with custom domain
- Refactor queries to the backend to use `useQuery`
- Simplified pagination

Note: Queries are poorly cached at the moment; we should leverage react-query pagination by adding pagination support in the backend. See #39 

Fixes #37 